### PR TITLE
chore: Add unused dependencies check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
+      - name: Check for unused dependencies
+        run: |
+          cargo install cargo-machete
+          cargo machete check --fail
+          
   cargo-audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
         run: cargo test --doc --all-features
 
       - name: Install cargo-machete and Check for unused dependencies
-        run: |
-          cargo install cargo-machete
-          cargo machete check --fail
+        uses: bnjbvr/cargo-machete@main
+        with:
+          args: check --fail 
       
   cargo-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
-      - name: Install cargo-machete and Check for unused dependencies
+      - name: Check for unused dependencies
         uses: bnjbvr/cargo-machete@main
         with:
           args: check --fail 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,18 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      
+
       - name: Optimize Build Performance
         uses: rui314/setup-mold@v1
-      
+
+      - name: Install Tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: |
+            nextest
+            cargo-machete
+            cargo-audit
+
       - name: Format Check
         run: cargo fmt --all --check
 
@@ -28,29 +36,22 @@ jobs:
         run: cargo build --all-features --all-targets
 
       - name: Cargo test
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
-      - run: cargo nextest run --all-features --all-targets
+        run: cargo nextest run --all-features --all-targets
 
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
       - name: Check for unused dependencies
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-machete
-          args: check --fail --with-metadata
+        run: cargo machete check --fail --with-metadata
 
-          
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Repository
         uses: actions/checkout@v4
+
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-audit
-      - run: cargo audit
+
+      - name: Run Cargo Audit
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,19 @@ jobs:
       - name: Cargo Build
         run: cargo build --all-features --all-targets
 
-      - name: Install test tools
+      - name: Cargo test
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest cargo-machete
-
-      - name: Cargo test
-        run: cargo nextest run --all-features --all-targets
+          tool: nextest
+      - run: cargo nextest run --all-features --all-targets
 
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
       - name: Check for unused dependencies
-        run: cargo machete check --fail --with-metadata
-
+        uses: bnjbvr/cargo-machete@main
+        with:
+          args: check --fail --with-metadata
       
   cargo-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install test tools
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest cargo-machete cargo-audit
+          tool: nextest cargo-machete
 
       - name: Cargo test
         run: cargo nextest run --all-features --all-targets
@@ -41,5 +41,15 @@ jobs:
       - name: Check for unused dependencies
         run: cargo machete check --fail --with-metadata
 
-      - name: Run cargo-audit
-        run: cargo audit
+      
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repository
+        uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,12 @@ jobs:
         run: cargo test --doc --all-features
 
       - name: Check for unused dependencies
-        uses: bnjbvr/cargo-machete@main
+        uses: taiki-e/install-action@v2
         with:
+          tool: cargo-machete
           args: check --fail --with-metadata
-      
+
+          
   cargo-audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,28 +27,19 @@ jobs:
       - name: Cargo Build
         run: cargo build --all-features --all-targets
 
-      - name: Cargo test
+      - name: Install test tools
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest
-      - run: cargo nextest run --all-features --all-targets
+          tool: nextest cargo-machete cargo-audit
+
+      - name: Cargo test
+        run: cargo nextest run --all-features --all-targets
 
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
       - name: Check for unused dependencies
-        uses: bnjbvr/cargo-machete@main
-        with:
-          args: check --fail 
-      
-  cargo-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch Repository
-        uses: actions/checkout@v4
-      - name: Install stable toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-audit
-      - run: cargo audit
+        run: cargo machete check --fail --with-metadata
+
+      - name: Run cargo-audit
+        run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-machete
-          args: check --fail --with-metadata
+          args: check --with-metadata
 
           
   cargo-audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,10 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-
+      
       - name: Optimize Build Performance
         uses: rui314/setup-mold@v1
-
-      - name: Install Tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: |
-            nextest
-            cargo-machete
-            cargo-audit
-
+      
       - name: Format Check
         run: cargo fmt --all --check
 
@@ -36,22 +28,29 @@ jobs:
         run: cargo build --all-features --all-targets
 
       - name: Cargo test
-        run: cargo nextest run --all-features --all-targets
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - run: cargo nextest run --all-features --all-targets
 
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
       - name: Check for unused dependencies
-        run: cargo machete check --fail --with-metadata
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+          args: check --fail --with-metadata
 
+          
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Repository
         uses: actions/checkout@v4
-
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Run Cargo Audit
-        run: cargo audit
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Run Documentation Tests
         run: cargo test --doc --all-features
 
-      - name: Check for unused dependencies
+      - name: Install cargo-machete and Check for unused dependencies
         run: |
           cargo install cargo-machete
           cargo machete check --fail
-          
+      
   cargo-audit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a step to the CI pipeline to check for unused dependencies using `cargo-machete`. The build will fail if any unused dependencies are found.
